### PR TITLE
Fix Grass-Skip milestone overflow.

### DIFF
--- a/style.css
+++ b/style.css
@@ -595,7 +595,7 @@ button:not(.locked):hover {
     background-color: limegreen !important;
 }
 
-#gh_mil_ctns {
+#gh_mil_ctns, #gs_mil_ctns {
     height: 100%;
 }
 


### PR DESCRIPTION
Grass-Skip milestones currently don't scroll, causing them to slip behind the Fun box. This is avoided by Grasshop, its counterpart, by way of limiting `#gh_mil_ctns`'s height. QED.