### PR TITLE
Use Decimal.add for adding numbers to Decimals

### DIFF
--- a/js/features/crystal.js
+++ b/js/features/crystal.js
@@ -506,7 +506,7 @@ UPGS.cloud = {
 
 tmp_update.push(()=>{
     tmp.crystalGain = MAIN.crystal.gain()
-    tmp.crystalGainP = (upgEffect('auto',12,0)+upgEffect('gen',1,0))*upgEffect('factory',1,1)
+    tmp.crystalGainP = Decimal.add(upgEffect('auto',12,0),upgEffect('gen',1,0)).mul(upgEffect('factory',1,1))
 
     tmp.oilGain = MAIN.oil.gain()
 

--- a/js/features/galactic.js
+++ b/js/features/galactic.js
@@ -6,7 +6,7 @@ MAIN.gal = {
 
         if (tmp.minStats.gs>0) y += getGSEffect(0,0)
 
-        let x = Decimal.pow(1.5+upgEffect('dm',5,0),Math.max(player.rocket.part-10,0))
+        let x = Decimal.pow(Decimal.add(1.5,upgEffect('dm',5,0)),Math.max(player.rocket.part-10,0))
 
         tmp.starGainBase = x
 

--- a/js/features/pp.js
+++ b/js/features/pp.js
@@ -495,7 +495,7 @@ UPGS.np = {
 
 tmp_update.push(()=>{
     tmp.ppGain = MAIN.pp.gain()
-    tmp.ppGainP = (upgEffect('auto',11,0)+upgEffect('gen',0,0))*upgEffect('factory',1,1)
+    tmp.ppGainP = Decimal.add(upgEffect('auto',11,0),upgEffect('gen',0,0)).mul(upgEffect('factory',1,1))
 
     tmp.apGain = MAIN.ap.gain()
 

--- a/js/main.js
+++ b/js/main.js
@@ -80,7 +80,7 @@ const MAIN = {
         return x
     },
     grassCap() {
-        let x = 10+upgEffect('grass',1,0)+upgEffect('perk',1,0)+upgEffect('ap',4,0)+starTreeEff('progress',0,0)
+        let x = Decimal.add(10,upgEffect('grass',1,0)).add(upgEffect('perk',1,0)).add(upgEffect('ap',4,0)).add(starTreeEff('progress',0,0))
 
         x *= upgEffect('unGrass',1,1)
 


### PR DESCRIPTION
This fixes a couple of bugs with addition between `number`s and `Decimal`s, namely:
* grass cap being stuck at 4000 (#12)
* automatically generated PP and Crystal amounts
* Dark Matter upgrade number 5 having no effect (the reason I noticed this bug)

Example of grass cap calculation before and after, showing why the grass cap was 4000 right away:
![image](https://github.com/user-attachments/assets/f9425721-f1bc-490f-8f25-dcb84994ec8c)

Example of Star gain calculation being fixed (live on left, fixed local on right):
![image](https://github.com/user-attachments/assets/a87e0c31-ff4b-4c07-9845-9e245143f655)
