### PR TITLE
Fix typo in galactic.js

### DIFF
--- a/js/features/galactic.js
+++ b/js/features/galactic.js
@@ -1461,7 +1461,7 @@ UPGRADES.moonstone = {
             icons: ["Curr/Steel2"],
 
             name: `Moon Steel`,
-            desc: `Increases platinum gained by <b class="green">+25%</b> per level.`,
+            desc: `Increases steel gained by <b class="green">+25%</b> per level.`,
 
             noCostIncrease: true,
             cost: ()=>1e3,


### PR DESCRIPTION
Changes a "platinum" to "steel" for the 12th moonstone upgrade "Steel II"